### PR TITLE
Feat: Add initial vault subgraph queries

### DIFF
--- a/src/Liquidator/helpers/index.ts
+++ b/src/Liquidator/helpers/index.ts
@@ -1,5 +1,3 @@
-import { liquidatorAccount } from "../../helpers";
-
 export { default as checkEtherBalance } from "./checkEtherBalance";
 export { fetchDeribitBestAskPrice } from "./deribit";
 export {
@@ -15,7 +13,5 @@ export {
   fetchShortOtokenInstrumentInfo,
 } from "./oTokenDetails";
 export { attemptSettlements, calculateSettleableVaults } from "./settlements";
-
-export const liquidatorAccountAddress = liquidatorAccount.address;
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
+++ b/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
@@ -11,95 +11,82 @@ import {
 import { updateSettlementStore } from "../settlements";
 import Liquidator from "../../index";
 import { Logger } from "../../../helpers";
+import { ILiquidatableVaults } from "../../types";
 
 export default async function attemptLiquidations(
   liquidatableVaultOwners: string[],
+  liquidatableVaults: ILiquidatableVaults,
   Liquidator: Liquidator
-) {
+): Promise<void> {
+  const settlementVaults = Liquidator.vaultStore.getSettlementVaults();
   const underlyingAsset = Liquidator.priceFeedStore.getUnderlyingAsset();
 
   for (const liquidatableVaultOwner of liquidatableVaultOwners) {
     await Promise.all(
-      Liquidator.liquidatableVaults[liquidatableVaultOwner].map(
-        async (vault) => {
-          try {
-            const shortOtokenInstrumentInfo =
-              await fetchShortOtokenInstrumentInfo(vault.shortOtokenAddress);
+      liquidatableVaults[liquidatableVaultOwner].map(async (vault) => {
+        try {
+          const shortOtokenInstrumentInfo =
+            await fetchShortOtokenInstrumentInfo(vault.shortOtokenAddress);
 
-            const [
-              ,
+          const [
+            ,
+            underlyingAssetAddress,
+            strikeAssetAddress,
+            strikePrice,
+            expiryTimestamp,
+            isPutOption,
+          ] = await fetchShortOtokenDetails(vault.shortOtokenAddress);
+
+          const collateralAssetDecimals = await fetchCollateralAssetDecimals(
+            vault.collateralAssetAddress
+          );
+
+          const deribitBestAskPrice = await fetchDeribitBestAskPrice({
+            ...shortOtokenInstrumentInfo,
+            underlyingAsset,
+          });
+
+          const collateralAssetNakedMarginRequirement =
+            await marginCalculatorContract.getNakedMarginRequired(
               underlyingAssetAddress,
               strikeAssetAddress,
+              vault.collateralAssetAddress,
+              vault.shortAmount,
               strikePrice,
+              vault.latestUnderlyingAssetPrice,
               expiryTimestamp,
-              isPutOption,
-            ] = await fetchShortOtokenDetails(vault.shortOtokenAddress);
-
-            const collateralAssetDecimals = await fetchCollateralAssetDecimals(
-              vault.collateralAssetAddress
+              collateralAssetDecimals,
+              isPutOption
             );
 
-            const deribitBestAskPrice = await fetchDeribitBestAskPrice({
-              ...shortOtokenInstrumentInfo,
-              underlyingAsset,
+          const liquidatorVaultNonce = setLiquidationVaultNonce(
+            expiryTimestamp,
+            Liquidator,
+            settlementVaults,
+            vault
+          );
+
+          const estimatedLiquidationTransactionCost =
+            await calculateLiquidationTransactionCost({
+              collateralToDeposit: collateralAssetNakedMarginRequirement,
+              gasPriceStore: Liquidator.gasPriceStore,
+              liquidatorVaultNonce,
+              vault,
+              vaultOwnerAddress: liquidatableVaultOwner,
             });
 
-            const collateralAssetNakedMarginRequirement =
-              await marginCalculatorContract.getNakedMarginRequired(
-                underlyingAssetAddress,
-                strikeAssetAddress,
-                vault.collateralAssetAddress,
-                vault.shortAmount,
-                strikePrice,
-                vault.latestUnderlyingAssetPrice,
-                expiryTimestamp,
-                collateralAssetDecimals,
-                isPutOption
-              );
-
-            const liquidatorVaultNonce = setLiquidationVaultNonce(
-              expiryTimestamp,
-              Liquidator,
-              vault
+          const estimatedProfit =
+            deribitBestAskPrice +
+            estimatedLiquidationTransactionCost +
+            Math.max(
+              Number(process.env.DERIBIT_PRICE_MULTIPLIER) *
+                deribitBestAskPrice,
+              Number(process.env.MINIMUM_LIQUIDATION_PRICE)
             );
 
-            const estimatedLiquidationTransactionCost =
-              await calculateLiquidationTransactionCost({
-                collateralToDeposit: collateralAssetNakedMarginRequirement,
-                gasPriceStore: Liquidator.gasPriceStore,
-                liquidatorVaultNonce,
-                vault,
-                vaultOwnerAddress: liquidatableVaultOwner,
-              });
-
-            const estimatedProfit =
-              deribitBestAskPrice +
-              estimatedLiquidationTransactionCost +
-              Math.max(
-                Number(process.env.DERIBIT_PRICE_MULTIPLIER) *
-                  deribitBestAskPrice,
-                Number(process.env.MINIMUM_LIQUIDATION_PRICE)
-              );
-
-            if (isPutOption) {
-              if (
-                vault.latestAuctionPrice.toNumber() / 10 ** 8 >
-                estimatedProfit
-              ) {
-                await liquidateVault({
-                  collateralToDeposit: collateralAssetNakedMarginRequirement,
-                  liquidatorVaultNonce,
-                  vault,
-                  vaultOwnerAddress: liquidatableVaultOwner,
-                });
-              }
-            }
-
+          if (isPutOption) {
             if (
-              ((vault.latestAuctionPrice.toNumber() /
-                10 ** collateralAssetDecimals) *
-                vault.latestUnderlyingAssetPrice.toNumber()) /
-                10 ** 8 >
+              vault.latestAuctionPrice.toNumber() / 10 ** 8 >
               estimatedProfit
             ) {
               await liquidateVault({
@@ -109,29 +96,44 @@ export default async function attemptLiquidations(
                 vaultOwnerAddress: liquidatableVaultOwner,
               });
             }
+          }
 
-            Logger.info({
-              at: "Liquidator#attemptLiquidations",
-              message: "Vault liquidated",
-              liquidatedVaultOwnerAddress: liquidatableVaultOwner,
-              vaultId: vault.vaultId.toString(),
-            });
-
-            return await updateSettlementStore(
-              Liquidator,
+          if (
+            ((vault.latestAuctionPrice.toNumber() /
+              10 ** collateralAssetDecimals) *
+              vault.latestUnderlyingAssetPrice.toNumber()) /
+              10 ** 8 >
+            estimatedProfit
+          ) {
+            await liquidateVault({
+              collateralToDeposit: collateralAssetNakedMarginRequirement,
               liquidatorVaultNonce,
-              vault
-            );
-          } catch (error) {
-            Logger.error({
-              alert: "Critical error during liquidation attempt",
-              at: "Liquidator#attemptLiquidations",
-              message: error.message,
-              error,
+              vault,
+              vaultOwnerAddress: liquidatableVaultOwner,
             });
           }
+
+          Logger.info({
+            at: "Liquidator#attemptLiquidations",
+            message: "Vault liquidated",
+            liquidatedVaultOwnerAddress: liquidatableVaultOwner,
+            vaultId: vault.vaultId.toString(),
+          });
+
+          return await updateSettlementStore(
+            Liquidator,
+            liquidatorVaultNonce,
+            vault
+          );
+        } catch (error) {
+          Logger.error({
+            alert: "Critical error during liquidation attempt",
+            at: "Liquidator#attemptLiquidations",
+            message: error.message,
+            error,
+          });
         }
-      )
+      })
     );
   }
 }

--- a/src/Liquidator/helpers/liquidations/fetchLiquidatableVaults.ts
+++ b/src/Liquidator/helpers/liquidations/fetchLiquidatableVaults.ts
@@ -39,41 +39,41 @@ export default async function fetchLiquidatableVaults(Liquidator: Liquidator) {
 
           if (!isUnderCollateralized) return;
 
-          if (Liquidator.liquidatableVaults[vaultOwnerAddress]) {
+          const liquidatableVaults = Liquidator.getLiquidatableVaults();
+
+          if (liquidatableVaults[vaultOwnerAddress]) {
             let vaultPresent = false;
             await Promise.all(
-              Liquidator.liquidatableVaults[vaultOwnerAddress].map(
-                async (vault) => {
-                  if (vaultId.eq(vault.vaultId)) {
-                    vaultPresent = true;
+              liquidatableVaults[vaultOwnerAddress].map(async (vault) => {
+                if (vaultId.eq(vault.vaultId)) {
+                  vaultPresent = true;
 
-                    if (!roundId.eq(vault.roundId)) {
-                      const [, oldRoundIdRecalculatedAuctionPrice] =
-                        await gammaControllerProxyContract.isLiquidatable(
-                          vaultOwnerAddress,
-                          vaultId,
-                          vault.roundId
-                        );
+                  if (!roundId.eq(vault.roundId)) {
+                    const [, oldRoundIdRecalculatedAuctionPrice] =
+                      await gammaControllerProxyContract.isLiquidatable(
+                        vaultOwnerAddress,
+                        vaultId,
+                        vault.roundId
+                      );
 
-                      if (
-                        currentRoundIdCalculatedAuctionPrice.gt(
-                          oldRoundIdRecalculatedAuctionPrice
-                        )
-                      ) {
-                        vault.latestAuctionPrice =
-                          currentRoundIdCalculatedAuctionPrice;
-                        vault.roundId = roundId;
-                      } else {
-                        vault.latestAuctionPrice =
-                          oldRoundIdRecalculatedAuctionPrice;
-                      }
+                    if (
+                      currentRoundIdCalculatedAuctionPrice.gt(
+                        oldRoundIdRecalculatedAuctionPrice
+                      )
+                    ) {
+                      vault.latestAuctionPrice =
+                        currentRoundIdCalculatedAuctionPrice;
+                      vault.roundId = roundId;
+                    } else {
+                      vault.latestAuctionPrice =
+                        oldRoundIdRecalculatedAuctionPrice;
                     }
                   }
                 }
-              )
+              })
             );
             if (!vaultPresent) {
-              Liquidator.liquidatableVaults[vaultOwnerAddress].push({
+              liquidatableVaults[vaultOwnerAddress].push({
                 latestAuctionPrice: currentRoundIdCalculatedAuctionPrice,
                 latestUnderlyingAssetPrice: answer,
                 collateralAssetAddress,
@@ -84,7 +84,7 @@ export default async function fetchLiquidatableVaults(Liquidator: Liquidator) {
               });
             }
           } else {
-            Liquidator.liquidatableVaults[vaultOwnerAddress] = [
+            liquidatableVaults[vaultOwnerAddress] = [
               {
                 latestAuctionPrice: currentRoundIdCalculatedAuctionPrice,
                 latestUnderlyingAssetPrice: answer,

--- a/src/Liquidator/helpers/liquidations/misc.ts
+++ b/src/Liquidator/helpers/liquidations/misc.ts
@@ -70,7 +70,7 @@ export async function calculateLiquidationTransactionCost({
   liquidatorVaultNonce,
   vault,
   vaultOwnerAddress,
-}: IMintAndLiquidateArgs & { gasPriceStore: GasPriceStore }) {
+}: IMintAndLiquidateArgs & { gasPriceStore: GasPriceStore }): Promise<number> {
   const mintAndLiquidationActions = generateMintAndLiquidateActions({
     collateralToDeposit,
     liquidatorVaultNonce,

--- a/src/Liquidator/helpers/liquidations/misc.ts
+++ b/src/Liquidator/helpers/liquidations/misc.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { liquidatorAccountAddress, ZERO_ADDRESS } from "../";
+import { ZERO_ADDRESS } from "../";
 import { ActionType } from "../actionTypes";
 import { fetchDeribitETHIndexPrice } from "../deribit";
 import marginCalculatorABI from "../marginCalculatorABI";
@@ -9,6 +9,7 @@ import GasPriceStore from "../../../GasPriceStore";
 import {
   gammaControllerProxyContract,
   liquidatorAccount,
+  liquidatorAccountAddress,
   provider,
 } from "../../../helpers";
 

--- a/src/Liquidator/helpers/liquidations/setLiquidationVaultNonce.ts
+++ b/src/Liquidator/helpers/liquidations/setLiquidationVaultNonce.ts
@@ -6,17 +6,16 @@ import { ILiquidatableVault } from "../../types";
 export default function setLiquidationVaultNonce(
   expiryTimestamp: BigNumber,
   Liquidator: Liquidator,
+  settlementVaults: Liquidator["vaultStore"]["settlementVaults"],
   { shortOtokenAddress }: ILiquidatableVault
-) {
-  if (Liquidator.settlementStore[shortOtokenAddress]) {
-    return BigNumber.from(
-      Object.keys(Liquidator.settlementStore[shortOtokenAddress])[0]
-    );
+): BigNumber {
+  if (settlementVaults[shortOtokenAddress]) {
+    return BigNumber.from(Object.keys(settlementVaults[shortOtokenAddress])[0]);
   }
 
   const liquidatorVaultNonce = Liquidator.latestLiquidatorVaultNonce;
 
-  Liquidator.settlementStore[shortOtokenAddress] = {
+  settlementVaults[shortOtokenAddress] = {
     [`${liquidatorVaultNonce.toString()}`]: {
       expiryTimestamp,
       shortAmount: BigNumber.from(0),

--- a/src/Liquidator/helpers/settlements/attemptSettlements.ts
+++ b/src/Liquidator/helpers/settlements/attemptSettlements.ts
@@ -4,7 +4,7 @@ import { Logger } from "../../../helpers";
 
 export default async function attemptSettlements(
   settleableVaults: ISettleableVaults
-) {
+): Promise<void> {
   const settleableVaultNonces = Object.keys(settleableVaults);
 
   for (

--- a/src/Liquidator/helpers/settlements/calculateSettleableVaults.ts
+++ b/src/Liquidator/helpers/settlements/calculateSettleableVaults.ts
@@ -1,17 +1,17 @@
 import { BigNumber } from "ethers";
 
 import Liquidator from "../../index";
-import { ISettleableVaults } from "../../types";
 
 export default function calculateSettleableVaults(
   Liquidator: Liquidator,
   updatedTimestamp: BigNumber
-) {
-  const settleableVaults: ISettleableVaults = {};
-  const settledShortOtokens = Object.keys(Liquidator.settlementStore);
+): Liquidator["settleableVaults"] {
+  const settlementVaults = Liquidator.vaultStore.getSettlementVaults();
+  const settledShortOtokens = Object.keys(settlementVaults);
+  const settleableVaults = Liquidator.getSettleableVaults();
 
   for (const settledShortOtoken of settledShortOtokens) {
-    const settlementVault = Liquidator.settlementStore[settledShortOtoken];
+    const settlementVault = settlementVaults[settledShortOtoken];
     const settlementVaultNonce = Object.keys(settlementVault)[0];
     const settlementDetails = settlementVault[settlementVaultNonce];
 

--- a/src/Liquidator/helpers/settlements/settleVault.ts
+++ b/src/Liquidator/helpers/settlements/settleVault.ts
@@ -10,7 +10,7 @@ import {
 export default async function settleVault(
   settleableVaultNonce: string,
   shortAmount: BigNumber
-) {
+): Promise<void> {
   const settleAction = [
     {
       actionType: ActionType.SettleVault,

--- a/src/Liquidator/helpers/settlements/settleVault.ts
+++ b/src/Liquidator/helpers/settlements/settleVault.ts
@@ -1,8 +1,11 @@
 import { BigNumber } from "ethers";
 
-import { liquidatorAccountAddress, ZERO_ADDRESS } from "../";
+import { ZERO_ADDRESS } from "../";
 import { ActionType } from "../actionTypes";
-import { gammaControllerProxyContract } from "../../../helpers";
+import {
+  liquidatorAccountAddress,
+  gammaControllerProxyContract,
+} from "../../../helpers";
 
 export default async function settleVault(
   settleableVaultNonce: string,

--- a/src/Liquidator/helpers/settlements/updateSettlementStore.ts
+++ b/src/Liquidator/helpers/settlements/updateSettlementStore.ts
@@ -4,11 +4,11 @@ import Liquidator from "../../index";
 import { ILiquidatableVault } from "../../types";
 
 export default function updateSettlementStore(
-  Liquidator: Liquidator,
+  { vaultStore: { settlementVaults } }: Liquidator,
   liquidatorVaultNonce: BigNumber,
   { shortAmount, shortOtokenAddress }: ILiquidatableVault
 ) {
-  return Liquidator.settlementStore[shortOtokenAddress][
+  return settlementVaults[shortOtokenAddress][
     liquidatorVaultNonce.toString()
   ].shortAmount.add(shortAmount);
 }

--- a/src/Liquidator/types.ts
+++ b/src/Liquidator/types.ts
@@ -22,18 +22,5 @@ export interface IMintAndLiquidateArgs {
 }
 
 export interface ISettleableVaults {
-  [liquidationVaultNonce: string]: ILiquidatableVault["shortAmount"];
-}
-
-export interface ISettlementDetails {
-  expiryTimestamp: BigNumber;
-  shortAmount: ILiquidatableVault["shortAmount"];
-}
-
-export interface ISettlementStore {
-  [shortOtokenAddress: string]: ISettlementVault;
-}
-
-export interface ISettlementVault {
-  [liquidationVaultNonce: string]: ISettlementDetails;
+  [settleableVaultNonce: string]: BigNumber;
 }

--- a/src/PriceFeedStore/index.ts
+++ b/src/PriceFeedStore/index.ts
@@ -21,15 +21,15 @@ export default class PriceFeedStore {
     this.underlyingAsset = "";
   }
 
-  public getLatestRoundData() {
+  public getLatestRoundData(): ILatestRoundData {
     return this.latestRoundData;
   }
 
-  public getUnderlyingAsset() {
+  public getUnderlyingAsset(): string {
     return this.underlyingAsset;
   }
 
-  start = () => {
+  start = (): void => {
     Logger.info({
       at: "PriceFeedStore#start",
       message: "Starting price feed store",
@@ -37,7 +37,7 @@ export default class PriceFeedStore {
     this._subscribe();
   };
 
-  _fetchPriceFeedPair = async () => {
+  _fetchPriceFeedPair = async (): Promise<void> => {
     try {
       const priceFeedPair =
         await chainlinkAggregatorProxyContract.description();
@@ -59,7 +59,7 @@ export default class PriceFeedStore {
     }
   };
 
-  _fetchLatestRoundData = async () => {
+  _fetchLatestRoundData = async (): Promise<void> => {
     try {
       const { answer, roundId, updatedAt } =
         await chainlinkAggregatorProxyContract.latestRoundData();
@@ -82,7 +82,7 @@ export default class PriceFeedStore {
     }
   };
 
-  _subscribe = async () => {
+  _subscribe = async (): Promise<void> => {
     await this._fetchLatestRoundData();
     await this._fetchPriceFeedPair();
 
@@ -104,7 +104,7 @@ export default class PriceFeedStore {
     }
   };
 
-  _subscribeToAnswerUpdatedEvents = async () => {
+  _subscribeToAnswerUpdatedEvents = async (): Promise<void> => {
     const chainlinkAggregatorContract = chainlinkAggregatorProxyContract.attach(
       await chainlinkAggregatorProxyContract.aggregator()
     );

--- a/src/VaultStore/fetchNakedMarginVaults.ts
+++ b/src/VaultStore/fetchNakedMarginVaults.ts
@@ -1,0 +1,72 @@
+import { BigNumber } from "ethers";
+import fetch from "node-fetch";
+
+import supportedNetworkSubgraphs from "./supportedNetworkSubgraphs";
+import { INakedMarginVaults } from "./types";
+import { liquidatorAccountAddress, Logger, provider } from "../helpers";
+
+export default async function fetchNakedMarginVaults(): Promise<INakedMarginVaults> {
+  const networkChainId = (await provider.getNetwork()).chainId.toString();
+
+  const subgraphUrl = supportedNetworkSubgraphs[networkChainId];
+
+  if (!subgraphUrl) {
+    Logger.error({
+      at: "VaultStore#fetchNakedMarginVaults",
+      message: "Warning: No subgraph for detected Ethereum network",
+    });
+    return {};
+  }
+
+  const nakedMarginVaultQuery = JSON.stringify({
+    query: `
+      {
+        vaults(where: { owner_not: "${liquidatorAccountAddress}" type: 1 }) {
+          owner {
+            address: id
+            }
+          vaultId
+        }
+      }`,
+  });
+
+  try {
+    const {
+      data: { vaults },
+    } = await (
+      await fetch(subgraphUrl, {
+        body: nakedMarginVaultQuery,
+        method: "POST",
+      })
+    ).json();
+
+    const nakedMarginVaults: INakedMarginVaults = vaults.reduce(
+      (
+        nakedMarginVaults: INakedMarginVaults,
+        {
+          owner: { address },
+          vaultId,
+        }: { owner: { address: string }; vaultId: string }
+      ) => {
+        if (!nakedMarginVaults[address]) nakedMarginVaults[address] = [];
+        return {
+          ...nakedMarginVaults,
+          [address]: [
+            ...nakedMarginVaults[`${address}`],
+            BigNumber.from(vaultId),
+          ],
+        };
+      },
+      {}
+    );
+
+    return nakedMarginVaults;
+  } catch (error) {
+    Logger.error({
+      at: "VaultStore#fetchNakedMarginVaults",
+      message: error.message,
+      error,
+    });
+    return {};
+  }
+}

--- a/src/VaultStore/fetchSettlementVaults.ts
+++ b/src/VaultStore/fetchSettlementVaults.ts
@@ -1,0 +1,80 @@
+import { BigNumber } from "ethers";
+import fetch from "node-fetch";
+
+import supportedNetworkSubgraphs from "./supportedNetworkSubgraphs";
+import { ISettlementVaults } from "./types";
+import { liquidatorAccountAddress, Logger, provider } from "../helpers";
+
+export default async function fetchSettlementVaults(): Promise<ISettlementVaults> {
+  const networkChainId = (await provider.getNetwork()).chainId.toString();
+
+  const subgraphUrl = supportedNetworkSubgraphs[networkChainId];
+
+  if (!subgraphUrl) {
+    Logger.error({
+      at: "VaultStore#fetchSettlementVaults",
+      message: "Warning: No subgraph for detected Ethereum network",
+    });
+    return {};
+  }
+
+  const settlementVaultQuery = JSON.stringify({
+    query: `
+      {
+        vaults(where: { owner: "${liquidatorAccountAddress}" shortOToken_not: null type: 1 }) {
+          shortAmount
+          shortOToken {
+            address: id
+            expiryTimestamp
+          }
+          vaultId
+        }
+      }`,
+  });
+
+  try {
+    const {
+      data: { vaults },
+    } = await (
+      await fetch(subgraphUrl, {
+        body: settlementVaultQuery,
+        method: "POST",
+      })
+    ).json();
+
+    const settlementVaults: ISettlementVaults = vaults.reduce(
+      (
+        settlementVaults: ISettlementVaults,
+        {
+          shortAmount,
+          shortOToken: { address, expiryTimestamp },
+          vaultId,
+        }: {
+          shortAmount: string;
+          shortOToken: { address: string; expiryTimestamp: string };
+          vaultId: string;
+        }
+      ) => {
+        return {
+          ...settlementVaults,
+          [address]: {
+            [vaultId]: {
+              expiryTimestamp: BigNumber.from(expiryTimestamp),
+              shortAmount: BigNumber.from(shortAmount),
+            },
+          },
+        };
+      },
+      {}
+    );
+
+    return settlementVaults;
+  } catch (error) {
+    Logger.error({
+      at: "VaultStore#fetchSettlementVaults",
+      message: error.message,
+      error,
+    });
+    return {};
+  }
+}

--- a/src/VaultStore/index.ts
+++ b/src/VaultStore/index.ts
@@ -1,24 +1,27 @@
-import { BigNumber } from "ethers";
-
 import { openedNakedMarginVaultEvents } from "./eventFilters";
+import fetchNakedMarginVaults from "./fetchNakedMarginVaults";
+import fetchSettlementVaults from "./fetchSettlementVaults";
 import { gammaControllerProxyContract, Logger } from "../helpers";
-
-export interface INakedMarginVaults {
-  [vaultOwnerAddress: string]: BigNumber[];
-}
+import { INakedMarginVaults, ISettlementVaults } from "./types";
 
 export default class VaultStore {
   public nakedMarginVaults: INakedMarginVaults;
+  public settlementVaults: ISettlementVaults;
 
   constructor() {
     this.nakedMarginVaults = {};
+    this.settlementVaults = {};
   }
 
   public getNakedMarginVaults(): INakedMarginVaults {
     return this.nakedMarginVaults;
   }
 
-  start = () => {
+  public getSettlementVaults(): ISettlementVaults {
+    return this.settlementVaults;
+  }
+
+  start = (): void => {
     Logger.info({
       at: "VaultStore#start",
       message: "Starting vault store",
@@ -28,13 +31,11 @@ export default class VaultStore {
 
   _fetchNakedMarginVaults = async (): Promise<void> => {
     try {
-      // TODO: subgraph call to fetch naked margin vaults on startup
-
-      // this.nakedMarginVaults = ...;
+      this.nakedMarginVaults = await fetchNakedMarginVaults();
 
       Logger.info({
         at: "VaultStore#_fetchNakedMarginVaults",
-        message: "Vault store initialized",
+        message: "Naked margin vault store initialized",
         numberOfNakedMarginVaults: Object.values(this.nakedMarginVaults).flat()
           .length,
       });
@@ -47,8 +48,28 @@ export default class VaultStore {
     }
   };
 
-  _subscribe = async () => {
+  _fetchSettlementVaults = async (): Promise<void> => {
+    try {
+      this.settlementVaults = await fetchSettlementVaults();
+
+      Logger.info({
+        at: "VaultStore#_fetchSettlementVaults",
+        message: "Settlement vault store initialized",
+        numberOfSettlementVaults: Object.values(this.settlementVaults).flat()
+          .length,
+      });
+    } catch (error) {
+      Logger.error({
+        at: "VaultStore#_fetchSettlementVaults",
+        message: error.message,
+        error,
+      });
+    }
+  };
+
+  _subscribe = async (): Promise<void> => {
     await this._fetchNakedMarginVaults();
+    await this._fetchSettlementVaults();
 
     Logger.info({
       at: "VaultStore#_subscribe",

--- a/src/VaultStore/index.ts
+++ b/src/VaultStore/index.ts
@@ -14,7 +14,7 @@ export default class VaultStore {
     this.nakedMarginVaults = {};
   }
 
-  public getNakedMarginVaults() {
+  public getNakedMarginVaults(): INakedMarginVaults {
     return this.nakedMarginVaults;
   }
 
@@ -26,7 +26,7 @@ export default class VaultStore {
     this._subscribe();
   };
 
-  _fetchNakedMarginVaults = async () => {
+  _fetchNakedMarginVaults = async (): Promise<void> => {
     try {
       // TODO: subgraph call to fetch naked margin vaults on startup
 
@@ -68,7 +68,7 @@ export default class VaultStore {
     }
   };
 
-  _subscribeToOpenedNakedMarginVaultEvents = async () => {
+  _subscribeToOpenedNakedMarginVaultEvents = async (): Promise<void> => {
     gammaControllerProxyContract.on(
       openedNakedMarginVaultEvents,
       async (vaultOwner, vaultId) => {

--- a/src/VaultStore/supportedNetworkSubgraphs.ts
+++ b/src/VaultStore/supportedNetworkSubgraphs.ts
@@ -1,0 +1,7 @@
+export const supportedNetworkSubgraphs: { [chainId: string]: string } = {
+  "1": "https://api.thegraph.com/subgraphs/name/opynfinance/gamma-mainnet", // mainnet subgraph
+  "3": "https://api.thegraph.com/subgraphs/name/opynfinance/gamma-ropsten", // ropsten subgraph
+  "42": "https://api.thegraph.com/subgraphs/name/opynfinance/gamma-internal-kovan", // kovan subgraph
+};
+
+export default supportedNetworkSubgraphs;

--- a/src/VaultStore/types.ts
+++ b/src/VaultStore/types.ts
@@ -1,0 +1,18 @@
+import { BigNumber } from "ethers";
+
+export interface INakedMarginVaults {
+  [vaultOwnerAddress: string]: BigNumber[];
+}
+
+export interface ISettlementDetails {
+  expiryTimestamp: BigNumber;
+  shortAmount: BigNumber;
+}
+
+export interface ISettlementVaults {
+  [shortOtokenAddress: string]: ISettlementVault;
+}
+
+export interface ISettlementVault {
+  [settlementVaultNonce: string]: ISettlementDetails;
+}

--- a/src/helpers/delay.ts
+++ b/src/helpers/delay.ts
@@ -1,1 +1,0 @@
-export const delay = (ms: any) => new Promise(r => setTimeout(r, ms));

--- a/src/helpers/ethers.ts
+++ b/src/helpers/ethers.ts
@@ -33,6 +33,8 @@ export const liquidatorAccount = new ethers.Wallet(
   provider
 );
 
+export const liquidatorAccountAddress = liquidatorAccount.address;
+
 export async function loadLiquidatorAccount() {
   gammaControllerProxyContract =
     gammaControllerProxyContract.connect(liquidatorAccount);

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,3 @@
-export { delay } from "./delay";
 export {
   chainlinkAggregatorProxyContract,
   gammaControllerProxyContract,

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,6 +3,7 @@ export {
   chainlinkAggregatorProxyContract,
   gammaControllerProxyContract,
   liquidatorAccount,
+  liquidatorAccountAddress,
   loadLiquidatorAccount,
   provider,
 } from "./ethers";

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -41,7 +41,7 @@ if (process.env.LOGS === "true") {
       level: "debug",
       handleExceptions: true,
       format: alignedWithColorsAndTime,
-    }) as any
+    }) as StackTransport
   );
 }
 


### PR DESCRIPTION
- feat: add `supportedNetworkSubgraphs` helper
- refactor: add & re-org `VaultStore` relevant typings
- refactor: export `liquidatorAccountAddress` from `src/helpers/index`
- refactor: rm unused `delay` helper
- refactor: misc typing
- feat: add `fetchSettlementVaults` helper, subgraph query for settlement vaults
- feat: add `fetchNakedMarginVaults` helper, subgraph query for naked margin vaults
- refactor: update `Liquidator` typings, add getter fns for liquidatable & settleable vaults, update code as necessary
- feat: integrate subgraph helpers into `VaultStore`, update typings, add getter fn for settlement vaults