### PR TITLE
Feat: retry liquidation logic

### DIFF
--- a/src/Liquidator/helpers/abis/oToken.ts
+++ b/src/Liquidator/helpers/abis/oToken.ts
@@ -1,7 +1,4 @@
 // minimal contract ABI needed for fetching oToken instrument info
-const oTokenABI = [
-  "function getOtokenDetails() external view returns (address, address, address, uint256, uint256, bool)",
-  "function symbol() public view returns (string)",
-];
+const oTokenABI = ["function symbol() public view returns (string)"];
 
 export default oTokenABI;

--- a/src/Liquidator/helpers/balances/checkCollateralAssetBalance.ts
+++ b/src/Liquidator/helpers/balances/checkCollateralAssetBalance.ts
@@ -5,7 +5,8 @@ import Liquidator from "../..";
 import { liquidatorAccountAddress, Logger, provider } from "../../../helpers";
 
 export default async function checkCollateralAssetBalance(
-  collateralAssetMarginRequirement: BigNumber,
+  collateralAssetMarginRequirement: number,
+  collateralAssetDecimals: BigNumber,
   liquidatableVaultOwner: string,
   {
     collateralAssetAddress,
@@ -24,8 +25,6 @@ export default async function checkCollateralAssetBalance(
   if (
     liquidatorAccountCollateralAssetBalance.lt(collateralAssetMarginRequirement)
   ) {
-    const collateralAssetDecimals = await collateralAssetContract.decimals();
-
     Logger.error({
       at: "Liquidator#checkCollateralAssetBalance",
       message:

--- a/src/Liquidator/helpers/index.ts
+++ b/src/Liquidator/helpers/index.ts
@@ -14,7 +14,6 @@ export {
 } from "./liquidations";
 export {
   fetchCollateralAssetDecimals,
-  fetchShortOtokenDetails,
   fetchShortOtokenInstrumentInfo,
 } from "./oTokenDetails";
 export { default as setLatestLiquidatorVaultNonce } from "./setLatestLiquidatorVaultNonce";

--- a/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
+++ b/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
@@ -33,8 +33,7 @@ export default async function attemptLiquidations(
           vault.shortOtokenAddress
         );
 
-        const [, , , , expiryTimestamp, isPutOption] =
-          await fetchShortOtokenDetails(vault.shortOtokenAddress);
+        const isPutOption = shortOtokenInstrumentInfo.optionType === "P";
 
         const collateralAssetDecimals: any = await fetchCollateralAssetDecimals(
           vault.collateralAssetAddress

--- a/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
+++ b/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
@@ -116,7 +116,7 @@ export default async function attemptLiquidations(
           }
         }
 
-        const [, collateralAssetMarginRequirement]: any =
+        let [, collateralAssetMarginRequirement]: any =
           await marginCalculatorContract.getMarginRequired(
             {
               collateralAmounts: [vault.collateralAmount],
@@ -128,6 +128,10 @@ export default async function attemptLiquidations(
             },
             0
           );
+
+        collateralAssetMarginRequirement =
+          (collateralAssetMarginRequirement / 1e27) *
+          10 ** collateralAssetDecimals;
 
         await checkCollateralAssetBalance(
           collateralAssetMarginRequirement,

--- a/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
+++ b/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
@@ -10,7 +10,6 @@ import {
   fetchDeribitBestAskPrice,
   fetchDeribitDelta,
   fetchDeribitMarkPrice,
-  fetchShortOtokenDetails,
   fetchShortOtokenInstrumentInfo,
   marginCalculatorContract,
   setLatestLiquidatorVaultNonce,

--- a/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
+++ b/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
@@ -131,6 +131,7 @@ export default async function attemptLiquidations(
 
         await checkCollateralAssetBalance(
           collateralAssetMarginRequirement,
+          collateralAssetDecimals,
           liquidatableVaultOwner,
           vault
         );

--- a/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
+++ b/src/Liquidator/helpers/liquidations/attemptLiquidations.ts
@@ -27,7 +27,7 @@ export default async function attemptLiquidations(
   const underlyingAsset = Liquidator.priceFeedStore.getUnderlyingAsset();
 
   for await (const liquidatableVaultOwner of liquidatableVaultOwners) {
-    liquidatableVaults[liquidatableVaultOwner].map(async (vault) => {
+    for await (const vault of liquidatableVaults[liquidatableVaultOwner]) {
       try {
         const shortOtokenInstrumentInfo = await fetchShortOtokenInstrumentInfo(
           vault.shortOtokenAddress
@@ -297,6 +297,6 @@ export default async function attemptLiquidations(
 
         return await setLatestLiquidatorVaultNonce(Liquidator);
       }
-    });
+    }
   }
 }

--- a/src/Liquidator/helpers/liquidations/misc.ts
+++ b/src/Liquidator/helpers/liquidations/misc.ts
@@ -18,7 +18,7 @@ export const generateMintAndLiquidateActions = ({
   liquidatorVaultNonce,
   vault,
   vaultOwnerAddress,
-}: IMintAndLiquidateArgs) => [
+}: IMintAndLiquidateArgs): any => [
   {
     actionType: ActionType.OpenVault,
     owner: liquidatorAccountAddress,

--- a/src/Liquidator/helpers/liquidations/operateTransaction.ts
+++ b/src/Liquidator/helpers/liquidations/operateTransaction.ts
@@ -1,0 +1,32 @@
+import Liquidator from "../..";
+import { gammaControllerProxyContract } from "../../../helpers";
+
+export default async function operateTransaction(
+  transactionParams: Record<string, any>[],
+  gasPriceStore: Liquidator["gasPriceStore"],
+  gasPrice: number
+): Promise<void> {
+  try {
+    const transaction = await gammaControllerProxyContract.operate(
+      transactionParams,
+      {
+        gasPrice,
+      }
+    );
+
+    await gammaControllerProxyContract.provider.waitForTransaction(
+      transaction.hash,
+      undefined,
+      60000 // 60 seconds
+    );
+
+    return;
+  } catch (_error) {
+    // try again
+    await operateTransaction(
+      transactionParams,
+      gasPriceStore,
+      (gasPriceStore.getLastCalculatedGasPrice() as any) * 1.1
+    );
+  }
+}

--- a/src/Liquidator/helpers/oTokenDetails.ts
+++ b/src/Liquidator/helpers/oTokenDetails.ts
@@ -16,18 +16,6 @@ export async function fetchCollateralAssetDecimals(
   return collateralAssetContract.decimals();
 }
 
-export async function fetchShortOtokenDetails(
-  shortOtokenAddress: string
-): Promise<any> {
-  const shortOtokenContract = new ethers.Contract(
-    shortOtokenAddress,
-    oTokenABI,
-    provider
-  );
-
-  return shortOtokenContract.getOtokenDetails();
-}
-
 export async function fetchShortOtokenInstrumentInfo(
   shortOtokenAddress: string
 ): Promise<any> {


### PR DESCRIPTION
- refactor: pass `collateralAssetDecimals` to `checkCollateralAssetBalance`, minimize `eth_call`s
- fix: scale down `collateralAssetMarginRequirement`s
- fix: attempt liquidations in series
- refactor: use parsed `shortOtoken` `optionType` to determine option type
- refactor: rm deprecated code for fetching `shortOtoken` details
- refactor: misc
- feat: `operateTransaction` helper for retrying pending liquidation transactions
- feat: integrate `operateTransaction` helper in `liquidateVault`