### PR TITLE
Refactor: infura errors

### DIFF
--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -47,6 +47,9 @@ if (process.env.LOGS === "true") {
 }
 
 if (process.env.SLACK_WEBHOOK) {
+  // tuple, [0] is the number of server error/timeout issues, [1] is timestamp in seconds
+  const infuraCounter = [0, Math.floor(Date.now() / 1000)];
+
   transports.push(
     new SlackHook({
       level: "error",
@@ -59,19 +62,36 @@ if (process.env.SLACK_WEBHOOK) {
             info.error.code === "SERVER_ERROR" ||
             info.error.code === "TIMEOUT"
           ) {
-            const { message, ...rest } = filteredInfo;
-            filteredInfo = { at: filteredInfo.at, message };
-            filteredInfo = {
-              ...rest,
-              error: `Infura ${
-                info.error.code === `SERVER_ERROR`
-                  ? `server error`
-                  : `request timeout`
-              }. Check https://status.infura.io/.`,
-            };
+            infuraCounter[0]++;
+
+            if (
+              infuraCounter[0] > 50 &&
+              Math.floor(Date.now() / 1000) - infuraCounter[1] < 300
+            ) {
+              const { message, ...rest } = filteredInfo;
+              filteredInfo = { at: filteredInfo.at, message };
+              filteredInfo = {
+                ...rest,
+                error: `Infura ${
+                  info.error.code === `SERVER_ERROR`
+                    ? `server error`
+                    : `request timeout`
+                }. Check https://status.infura.io/.`,
+              };
+
+              // reset counter
+              infuraCounter[0] = 0;
+            } else {
+              filteredInfo = {};
+            }
           } else {
+            // reset counter
+            infuraCounter[0] = 0;
             delete filteredInfo.error;
           }
+
+          // reset timestamp
+          infuraCounter[1] = Math.floor(Date.now() / 1000);
         }
 
         const stringifiedInfo = JSON.stringify(filteredInfo, null, " ");

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -106,7 +106,16 @@ if (process.env.SLACK_WEBHOOK) {
 if (process.env.SENTRY_DSN) {
   transports.push(
     new Sentry({
-      sentry: { dsn: process.env.SENTRY_DSN },
+      sentry: {
+        dsn: process.env.SENTRY_DSN,
+        ignoreErrors: [
+          "502",
+          "503",
+          "504",
+          "bad response",
+          "Request failed with status code 400",
+        ],
+      },
       level: "error",
     })
   );


### PR DESCRIPTION
- refactor: add `infuraCounter` to ensure slack logging of only critical errors
- refactor: ignore passing default infura errors to sentry to minimize noise